### PR TITLE
Chatspace group グループのサイドバー表示

### DIFF
--- a/app/assets/stylesheets/_leftcontent.scss
+++ b/app/assets/stylesheets/_leftcontent.scss
@@ -56,10 +56,12 @@ display: block;
     height: calc(100vh - 15%);
     color: #FFFFFF;
     &--group {
+      color: white;
       padding-top: 20px;
       font-size: 15px;
              }
       &--message {
+        color: white;
         padding-top: 5px;
         font-size: 11px;
         padding-bottom: 40px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,6 +21,6 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name, { :user_ids => [] })
 end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+
+
   def new
     @group = Group.new
     @group.users << current_user
@@ -21,6 +23,6 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, { :user_ids => [] })
+    params.require(:group).permit(:name, :user_ids => [] )
 end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,6 +23,6 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, :user_ids => [] )
+    params.require(:group).permit(:name, user_ids:[] )
 end
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,4 +1,4 @@
 class GroupUser < ApplicationRecord
-  belongs_to :groups
+  belongs_to :group
   belongs_to :user
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,11 @@
       = link_to new_group_path, class: "icon" do
         %i.fa.fa-pencil-square-o
   .side__Main
-    %p.side__Main--group sample
-    %p.side__Main--message Good bye world
+    - current_user.groups.each do |group|
+      = link_to group_messages_path do
+        .side__Main--group
+          = group.name
+        .side__Main--message
+          Good bye world
 
 =render partial:"main"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -8,7 +8,7 @@
       = link_to edit_user_path(current_user), class: "icon" do
         %i.fa.fa-cog
     .side__Header--edit
-      = link_to() do
+      = link_to new_group_path, class: "icon" do
         %i.fa.fa-pencil-square-o
   .side__Main
     %p.side__Main--group sample

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -12,7 +12,7 @@
         %i.fa.fa-pencil-square-o
   .side__Main
     - current_user.groups.each do |group|
-      = link_to group_messages_path do
+      = link_to group_messages_path(group) do
         .side__Main--group
           = group.name
         .side__Main--message


### PR DESCRIPTION
WHY
Message画面で、自分の所属する画面を見れると便利だから。

WHAT
-messgaes/index.html.hamlの編集（それに付随するscssファイルの編集）
- group_user.rbの編集
入力ミスで、モデルのネストができていなかったので、そこを解決した
-group.controllerの編集
グループ作成時に、nameカラムだけを送信かにしていたため、さらにuser_idをテーブルに送信できるようにした。

https://gyazo.com/d2217ed597311408a9241a9d20a0b060
