### PR TITLE
Chatspace message メッセージ表示の実装

### DIFF
--- a/app/views/messages/_main.html.haml
+++ b/app/views/messages/_main.html.haml
@@ -8,10 +8,7 @@
           Edit
     .main__Header--member MEMBER
   .main__Body
-    .main__Body--main.clearfix
-      .main__Body--name ryosukemaehira
-      .main__Body--date 2016/10/02 06:27:07
-      .main__Body--text なるほど
+    = render @messages
   .main__Footer
     = form_for [@group, @message] do |f|
       = f.text_field :body, class: 'main__Footer--placeholder', placeholder: 'type a message'

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,10 @@
+.main__Body--main.clearfix
+  .main__Body--name
+    = message.user.name
+  .main__Body--date
+    = message.created_at.strftime("%Y/%m/%d %H:%M")
+.main__Body--text
+  - if message.body.present?
+    %p.main__Body--content
+      = message.body
+  = image_tag message.image_url, class: 'main__Body--image' if message.image.present?


### PR DESCRIPTION
WHY
メッセージを表示できるようにすることで、チャットをより便利に行えるから

WHAT
送信したメッセージを、view上で表示できるようにした

- _main.html.hamlの編集
- _message.html.hamlの編集

https://gyazo.com/f18f1cccc900504816b25d75333f5dea